### PR TITLE
use enum as namespace, as Apple does in Combine

### DIFF
--- a/KakaJSON/Convert/Values.swift
+++ b/KakaJSON/Convert/Values.swift
@@ -11,7 +11,7 @@ import Foundation
 import CoreGraphics
 #endif
 
-public struct Values {
+public enum Values {
     static func value(_ val: Any?,
                       _ type: Any.Type,
                       _ defaultValue: @autoclosure () -> Any? = nil) -> Any? {


### PR DESCRIPTION
Use empty enum as namespace, like Apple does in Combine, https://developer.apple.com/documentation/combine/publishers, so users can't create unmeaning `Values()`.