### PR TITLE
return early if possible

### DIFF
--- a/KakaJSON/Extension/Dictionary+KJ.swift
+++ b/KakaJSON/Extension/Dictionary+KJ.swift
@@ -91,6 +91,8 @@ extension Dictionary where Key == String {
                 guard let index = Int(subKey),
                     case array.indices = index else { return nil }
                 value = array[index]
+            } else {
+                break
             }
         }
         return value


### PR DESCRIPTION
If a JSON key contains multiple dots but the JSON has a bad structure, we should return early instead of continues iterating.